### PR TITLE
Fixed AddProperty() in BaseVM to use the actual property value.

### DIFF
--- a/DotNetifyLib.Core/BaseVM/BaseVM.cs
+++ b/DotNetifyLib.Core/BaseVM/BaseVM.cs
@@ -183,7 +183,7 @@ namespace DotNetify
 
          property.Subscribe(_ => Changed(property.Name));
          RuntimeProperties.Add(property);
-         Set(property, property.Name);
+         Set(property.Value, property.Name);
          return property;
       }
 


### PR DESCRIPTION
When (BaseVM.cs) ```ReactiveProperty<T> AddProperty<T>(Type propertyType, ReactiveProperty<T> property)``` is called, the method sends the property object itself to (ObservableObject.cs) ```void Set<T>(T iValue, [CallerMemberName] string propertyName = null)``` instead of the value. I.e. (BaseVM.cs, AddProperty()) ```Set<ReactiveProperty<T>>(property, property.Name)```.

Is this intended or should the actual property value be used instead?